### PR TITLE
Remove white bullet points on the main page

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -44,10 +44,10 @@
 
     <!-- Navigation -->
     <ul id="side-navigation" class="hide@small">
-        <li class="statistic-holder">
+        <li class="hidden">
             <a class="link" ng-class="{ 'active' : activeStatistic == null }" ng-click="goHome()"></a>
         </li>
-        <li class="statistic-holder" ng-repeat="statistic in statistics">
+        <li class="hidden" ng-repeat="statistic in statistics">
             <a class="link" ng-class="{ 'active' : statistic == activeStatistic }" ng-click="goToClickedStatistic(statistic)"></a>
         </li>
     </ul>
@@ -95,7 +95,7 @@
                 <div ng-if="substatistic.display == 'mission'">
                     <countdown countdown-to="substatistic.result.launch_date_time" specificity="substatistic.result.launch_specificity" type="classic">
                     </countdown>
-					
+
                     <launch-date launch-specificity="substatistic.result.launch_specificity" launch-date-time="substatistic.result.launch_date_time"></launch-date>
 
                     <div class="launch-link">


### PR DESCRIPTION
Fixing #1 

I believe this is some sort of menu to navigate through all the stats but I can't remember seeing it on the previous version. As a temporary fix I hid these nav links before deciding what we should do with them.
Also removed the `statistics-holder` CSS class that is not defined anywhere in the project.

![image](https://cloud.githubusercontent.com/assets/6317823/24829862/6de66e72-1c7a-11e7-8c80-09b5b511ee30.png)
