### PR TITLE
Improve header and footer

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-/* http://meyerweb.com/eric/tools/css/reset/ 
+/* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
 */
@@ -8744,39 +8744,16 @@ form[name="subscribeForm"] .subscription-failed {
 .fade-in-out.ng-hide {
   opacity: 0; }
 
-#home .app-description {
-  padding: 0 10px; }
-
-#home p {
-  font-size: 16px;
-  line-height: 1.6; }
-  #home p.exclaim {
-    font-size: 48px; }
-    #home p.exclaim a {
-      text-decoration: none;
-      color: #ccac55;
-      font-weight: 400; }
-  .state-small #home p {
-    font-size: 14px; }
-  @media (max-width: 640px) {
-    #home p {
-      font-size: 14px; } }
-
-#home .description {
+#footer .description {
   position: absolute;
-  bottom: 0;
-  text-align: center;
+  top: 50%;
   width: 100%;
+  text-align: center;
   font-size: 12px; }
 
-#home .expando-button {
-  width: 150px;
-  -webkit-transition: width ease-in-out 0.5s 0s;
-          transition: width ease-in-out 0.5s 0s; }
-  #home .expando-button:hover {
-    width: 200px; }
-
-#home {
+#footer {
+  min-height: 0;
+  height: auto;
   background-image: url("../images/backgrounds/orbcommdark.jpg"); }
 
 #nextLaunch {

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,15 +4,9 @@
 @section('content')
 <body class="home" ng-controller="homeController" ng-strict-di ng-keydown="keypress($event)">
 
-    <!-- Navigation -->
-    <ul id="side-navigation" class="hide@small">
-        <li class="hidden">
-            <a class="link" ng-class="{ 'active' : activeStatistic == null }" ng-click="goHome()"></a>
-        </li>
-        <li class="hidden" ng-repeat="statistic in statistics">
-            <a class="link" ng-class="{ 'active' : statistic == activeStatistic }" ng-click="goToClickedStatistic(statistic)"></a>
-        </li>
-    </ul>
+    @if (Auth::isAdmin())
+        @include('templates.header', ['class' => 'no-background'])
+    @endif
 
     <!-- Statistics -->
     <div class="content-wrapper single-page background" ng-repeat="statistic in statistics" id="@{{ statistic.camelCaseType }}" du-scrollspy="@{{ substatistic.camelCaseType }}" href="#@{{ statistic.camelCaseType }}">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,44 +4,6 @@
 @section('content')
 <body class="home" ng-controller="homeController" ng-strict-di ng-keydown="keypress($event)">
 
-
-    @include('templates.header', ['class' => 'no-background'])
-
-    <!-- Main content -->
-    <div class="content-wrapper single-page background" id="home" du-scrollspy="home">
-        <h1>Welcome</h1>
-        <main>
-            <div class="app-description gr-12 gr-12@small">
-                <p class="exclaim"><a href="/">SpaceX Stats</a></p>
-
-                <p class="">SpaceX Stats is the first website dedicated entirely to following SpaceX and their missions. Countdown to upcoming launches, read about past missions, watch and follow missions live as they happen, and much more!</p>
-
-                <p class="hide@small">SpaceX Stats is currently in public beta, and as such, some features may not be entirely operational or may appear broken. Please send any bugs / corrections to <a href="https://www.reddit.com/user/brandtamos">/u/brandtamos</a>.</p>
-            </div>
-            <!--<div class="app-description gr-4 gr-12@small">
-                <p class="exclaim"><a href="/missioncontrol">Mission Control</a></p>
-
-                <p class="">Coming soon: Subscribe to Mission Control to get exclusive content, mission notifications via SMS and email, participate in the spaceflight fan community, and the ability to precisely locate and find a wealth of media using targeted search.</p>
-
-                <p class="hide@small">Mission Control is currently in private beta and will be releasing in early 2016.</p>
-            </div>
-            <div class="app-description gr-4 gr-12@small">
-                <p class="exclaim"><a href="/live">Live</a></p>
-
-                <p class="">Using SpaceX Stats Live, you can both watch SpaceX launches in real time and receive live updates pre- and post-mission to keep you informed on mission progress, outside of the webcast streams. With Imgur and Twitter integration, this is the single best way to be totally connected during a SpaceX launch.</p>
-
-                <p class="hide@small">No more hassles with refreshing antiquated forum pages or having multiple windows. Everything is in one place.</p>
-            </div>-->
-
-            <p class="description">Photos on this page courtesy SpaceX, & NASA. All rights maintained by the respective owners. <br/>
-            This site is fan-run and not affiliated with SpaceX in any way. For official information and news, please visit <a href="http://spacex.com">spacex.com</a><br />
-			Original site concept and design by <a href="https://www.reddit.com/user/echologic">/u/echologic</a>, now temporarily rehosted by <a href="https://www.reddit.com/user/brandtamos">/u/brandtamos</a>
-			</p>
-
-            <button class="next-stat" ng-click="goToFirstStatistic()"><i class="fa fa-angle-down fa-3x"></i></button>
-        </main>
-    </div>
-
     <!-- Navigation -->
     <ul id="side-navigation" class="hide@small">
         <li class="hidden">
@@ -119,5 +81,15 @@
             <button class="next-stat" ng-click="goToNeighborStatistic($index + 1)"><i class="fa fa-angle-down fa-3x"></i></button>
         </main>
     </div>
+
+    <footer class="content-wrapper background" id="footer" du-scrollspy="home">
+        <main>
+            <p class="description">
+                Photos on this page courtesy SpaceX, & NASA. All rights maintained by the respective owners. <br/>
+                This site is fan-run and not affiliated with SpaceX in any way. For official information and news, please visit <a href="http://spacex.com" title="Official SpaceX website">spacex.com</a><br />
+                Original site concept and design by <a href="https://www.reddit.com/user/echologic" title="Echologic's Reddit profile">/u/echologic</a>, now temporarily rehosted by <a href="https://www.reddit.com/user/brandtamos" title="Brandtamos' Reddit profile">/u/brandtamos</a>
+            </p>
+        </main>
+    </footer>
 </body>
 @stop


### PR DESCRIPTION
My proposition for a new header + footer:

* Moved the info text at the top to the bottom
* Removed the navlinks to only show the frontpage with stats

New "header":

![image](https://cloud.githubusercontent.com/assets/6317823/25785291/3194fa78-337d-11e7-89f0-28cd3943d962.png)

Footer:

![image](https://cloud.githubusercontent.com/assets/6317823/25785285/16210d0e-337d-11e7-92ad-d5de2df0a88c.png)

If you have suggestions...