### PR TITLE
Redis for vagrant, cache clear admin tool

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,5 +1,6 @@
 <?php
 namespace SpaceXStats\Http\Controllers;
+use Illuminate\Support\Facades\Cache;
 
 class AdminController extends Controller {
     public function index() {
@@ -7,4 +8,10 @@ class AdminController extends Controller {
 
         ));
     }
+	public function clearcache(){
+		Cache::flush();
+		return view('admin', array(
+
+        ));
+	}
 }

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -37,6 +37,7 @@ Route::get('faq/get', 'QuestionsController@get');
 Route::get('faq','QuestionsController@index');
 
 Route::get('admin', 'AdminController@index')->middleware(['mustBe:Administrator']);
+Route::get('admin/clearcache', 'AdminController@clearcache')->middleware(['mustBe:Administrator']);
 
 Route::get('newssummaries', 'NewsSummariesController@index');
 

--- a/devops/provision-dev.yml
+++ b/devops/provision-dev.yml
@@ -12,4 +12,5 @@
     - composer
     - mysql
     - laravel
+    - redis
     - vagrant

--- a/devops/roles/redis/tasks/main.yml
+++ b/devops/roles/redis/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: install Redis server
+  apt: name=redis-server state=latest update_cache=yes
+
+- name: check if Redis is running
+  service: name=redis-server state=started
+
+- name: enable redis-server to survive reboot
+  service: name=redis-server enabled=yes

--- a/resources/views/admin.blade.php
+++ b/resources/views/admin.blade.php
@@ -2,6 +2,7 @@
 @section('title', 'Admin')
 
 @section('content')
+
 <body class="admin">
 
     @include('templates.header')
@@ -11,14 +12,13 @@
         <main>
             <nav class="sticky-bar">
                 <ul class="container">
-                    <li class="gr-1">Stuff</li>
+                    <li class="gr-1"><b>Admin Tasks</b></li>
                 </ul>
             </nav>
             <section>
                 <ul>
                     <li><a href="/missions/create">Create A Mission</a></li>
-                    <li>Review Queue</li>
-                    <li>Meta Stats</li>
+					<li><a href="/admin/clearcache">Clear Laravel Cache</a></li>
                 </ul>
             </section>
         </main>


### PR DESCRIPTION
-Added redis install to the ansible provision roles for vagrant. This was needed because I was getting errors when trying to edit a mission on the vagrant box.

-Added a link to the admin menu that allows an admin to clear the laravel cache. This uses the Cache::clear() method in PHP. 